### PR TITLE
🔧 fix: Disable Gemini safety threshold override

### DIFF
--- a/providers/gemini/chat.go
+++ b/providers/gemini/chat.go
@@ -122,9 +122,9 @@ func ConvertFromChatOpenai(request *types.ChatCompletionRequest) (*GeminiChatReq
 
 	threshold := "BLOCK_NONE"
 
-	if strings.HasPrefix(request.Model, "gemini-2.0") && !strings.Contains(request.Model, "thinking") {
-		threshold = "OFF"
-	}
+	// if strings.HasPrefix(request.Model, "gemini-2.0") && !strings.Contains(request.Model, "thinking") {
+	// 	threshold = "OFF"
+	// }
 
 	geminiRequest := GeminiChatRequest{
 		Contents: make([]GeminiChatContent, 0, len(request.Messages)),


### PR DESCRIPTION
- Commented out the conditional safety threshold override for Gemini 2.0 models
- Reverted to default "BLOCK_NONE" threshold for all Gemini models

[//]: # "请按照以下格式关联 issue"
[//]: # "请在提交 PR 前确认所提交的功能可用，附上截图即可，这将有助于项目维护者 review & merge 该 PR，谢谢"
[//]: # "项目维护者一般仅在周末处理 PR，因此如若未能及时回复希望能理解"
[//]: # "请在提交 PR 之前删除上面的注释"

close #issue_number

我已确认该 PR 已自测通过，相关截图如下：
