### PR TITLE
🔧 fix: Adjust token handling for specific OpenAI-like models

### DIFF
--- a/controller/channel-test.go
+++ b/controller/channel-test.go
@@ -86,8 +86,8 @@ func buildTestRequest(modelName string) *types.ChatCompletionRequest {
 		Stream: false,
 	}
 
-	if strings.HasPrefix(modelName, "o1-") {
-		testRequest.MaxCompletionTokens = 2
+	if strings.HasPrefix(modelName, "o1") || strings.HasPrefix(modelName, "o3") {
+		testRequest.MaxCompletionTokens = 10
 	} else {
 		testRequest.MaxTokens = 2
 	}

--- a/providers/openai/chat.go
+++ b/providers/openai/chat.go
@@ -19,6 +19,11 @@ type OpenAIStreamHandler struct {
 }
 
 func (p *OpenAIProvider) CreateChatCompletion(request *types.ChatCompletionRequest) (openaiResponse *types.ChatCompletionResponse, errWithCode *types.OpenAIErrorWithStatusCode) {
+	if (strings.HasPrefix(request.Model, "o1") || strings.HasPrefix(request.Model, "o3")) && request.MaxTokens > 0 {
+		request.MaxCompletionTokens = request.MaxTokens
+		request.MaxTokens = 0
+	}
+
 	req, errWithCode := p.GetRequestTextBody(config.RelayModeChatCompletions, request.Model, request)
 	if errWithCode != nil {
 		return nil, errWithCode
@@ -59,6 +64,10 @@ func (p *OpenAIProvider) CreateChatCompletion(request *types.ChatCompletionReque
 }
 
 func (p *OpenAIProvider) CreateChatCompletionStream(request *types.ChatCompletionRequest) (requester.StreamReaderInterface[string], *types.OpenAIErrorWithStatusCode) {
+	if (strings.HasPrefix(request.Model, "o1") || strings.HasPrefix(request.Model, "o3")) && request.MaxTokens > 0 {
+		request.MaxCompletionTokens = request.MaxTokens
+		request.MaxTokens = 0
+	}
 	streamOptions := request.StreamOptions
 	// 如果支持流式返回Usage 则需要更改配置：
 	if p.SupportStreamOptions {


### PR DESCRIPTION
- Modified token configuration in channel test to support o1 and o3 model prefixes
- Updated OpenAI provider to convert MaxTokens to MaxCompletionTokens for o1 and o3 models
- Increased max completion tokens from 2 to 10 in test request configuration

[//]: # "请按照以下格式关联 issue"
[//]: # "请在提交 PR 前确认所提交的功能可用，附上截图即可，这将有助于项目维护者 review & merge 该 PR，谢谢"
[//]: # "项目维护者一般仅在周末处理 PR，因此如若未能及时回复希望能理解"
[//]: # "请在提交 PR 之前删除上面的注释"

close #issue_number

我已确认该 PR 已自测通过，相关截图如下：
