### PR TITLE
feat(bedrock): 添加支持Claude Sonnet 4和Opus 4新模型 (#721)

### DIFF
--- a/providers/bedrock/category/base.go
+++ b/providers/bedrock/category/base.go
@@ -45,16 +45,22 @@ func GetModelName(modelName string) string {
 		"us.claude-3-5-sonnet-20241022": "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
 		"us.claude-3-5-haiku-20241022":  "us.anthropic.claude-3-5-haiku-20241022-v1:0",
 		"us.claude-3-7-sonnet-20250219": "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+		"us.claude-sonnet-4-20250514":   "us.anthropic.claude-sonnet-4-20250514-v1:0",
+		"us.claude-opus-4-20250514":     "us.anthropic.claude-opus-4-20250514-v1:0",
 
 		"eu.claude-3-sonnet-20240229":   "eu.anthropic.claude-3-sonnet-20240229-v1:0",
 		"eu.claude-3-5-sonnet-20240620": "eu.anthropic.claude-3-5-sonnet-20240620-v1:0",
 		"eu.claude-3-haiku-20240307":    "eu.anthropic.claude-3-haiku-20240307-v1:0",
 		"eu.claude-3-7-sonnet-20250219": "eu.anthropic.claude-3-7-sonnet-20250219-v1:0",
+		"eu.claude-sonnet-4-20250514":   "eu.anthropic.claude-sonnet-4-20250514-v1:0",
+		"eu.claude-opus-4-20250514":     "eu.anthropic.claude-opus-4-20250514-v1:0",
 
 		"apac.claude-3-sonnet-20240229":   "apac.anthropic.claude-3-sonnet-20240229-v1:0",
 		"apac.claude-3-5-sonnet-20240620": "apac.anthropic.claude-3-5-sonnet-20240620-v1:0",
 		"apac.claude-3-haiku-20240307":    "apac.anthropic.claude-3-haiku-20240307-v1:0",
 		"apac.claude-3-7-sonnet-20250219": "apac.anthropic.claude-3-7-sonnet-20250219-v1:0",
+		"apac.claude-sonnet-4-20250514":   "apac.anthropic.claude-sonnet-4-20250514-v1:0",
+		"apac.claude-opus-4-20250514":     "apac.anthropic.claude-opus-4-20250514-v1:0",
 
 		//base model id
 		"claude-3-7-sonnet-20250219": "anthropic.claude-3-7-sonnet-20250219-v1:0",


### PR DESCRIPTION
更新Base模型映射以支持Claude Sonnet 4和Opus 4的多区域版本。

- 新增了us、eu、apac区域的Sonnet 4和Opus 4模型映射。

[//]: # "请按照以下格式关联 issue"
[//]: # "请在提交 PR 前确认所提交的功能可用，附上截图即可，这将有助于项目维护者 review & merge 该 PR，谢谢"
[//]: # "项目维护者一般仅在周末处理 PR，因此如若未能及时回复希望能理解"
[//]: # "请在提交 PR 之前删除上面的注释"

close #issue_number

我已确认该 PR 已自测通过，相关截图如下：
